### PR TITLE
feature: rely on gh cli for pushing tags and releases

### DIFF
--- a/.github/workflows/publish_version.yml
+++ b/.github/workflows/publish_version.yml
@@ -29,7 +29,9 @@ jobs:
         run: |
           if script -q -e -c "gh release view ${{ steps.release_version.outputs.version }}"; then
             # removing previous release along with associated tag
-            gh release delete ${{ steps.release_version.outputs.version }} --cleanup-tag -y
+            gh release delete ${{ steps.release_version.outputs.version }} \
+              --cleanup-tag -y \
+              --repo ${{ env.OWNER }}/${{ env.REPO }}
           else
             # non-exist
             echo "No trace of a previous release."

--- a/.github/workflows/publish_version.yml
+++ b/.github/workflows/publish_version.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,25 +25,32 @@ jobs:
           git fetch --filter=tree:0 origin +refs/tags/*:refs/tags/*
           echo "VERSION=$(echo ${{ github.head_ref }}|grep -Eo '[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_OUTPUT
           echo "PREVIOUS_VERSION=`echo $(git tag --list | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
-      - name: Creating the version tag
+      - name: Remove previous releases of the target tag, if existing
         run: |
-          git config user.email "actions@github.com"
-          git config user.name "github_actions"
-          git tag -a ${{ steps.release_version.outputs.version }} -f -m 'Published Version'
-      - name: Push changes
-        uses: ad-m/github-push-action@v0.8.0
-        with:
-          branch: ${{ github.head_ref }}  # NOTE: this we re-introduce the source branch if it was deleted
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          force: true
-          tags: true
+          if script -q -e -c "gh release view ${{ steps.release_version.outputs.version }}"; then
+            # removing previous release along with associated tag
+            gh release delete ${{ steps.release_version.outputs.version }} --cleanup-tag -y
+          else
+            # non-exist
+            echo "No trace of a previous release."
+          fi
+          gh label create ${{ env.LABEL_CHECK }} --repo ${{ env.OWNER }}/${{ env.REPO }}
       - name: Prepare Release note
         # this gets the first the changes to the previous clean tag (including manual edits)
         run: |
           awk '/<a name="${{ steps.release_version.outputs.version }}".*/{a=1};a;/<a name="${{ steps.release_version.outputs.previous_version }}"*/{exit}' CHANGELOG.md | head -n -1 >> body.md
-      - uses: ncipollo/release-action@v1
-        with:
-          commit: ${{ github.event.pull_request.head.sha }}
-          tag: ${{ steps.release_version.outputs.version }}
-          bodyFile: "body.md"
-          allowUpdates: true
+      - name: Create tag and release
+        run: |
+          gh release create ${{ steps.release_version.outputs.version }} \
+            --target ${{ github.event.pull_request.head.sha }} \
+            --latest \
+            --title "${{ }}" \
+            --notes-file body.md \
+            --repo ${{ env.OWNER }}/${{ env.REPO }}
+      # - name: Upload additional artifacts to the release
+      #   run: |
+      #     gh release upload ${{ steps.release_version.outputs.version }} \
+      #       some_file.md \
+      #       other_file.md \
+      #       --clobber
+      #       --repo ${{ env.OWNER }}/${{ env.REPO }}


### PR DESCRIPTION
Closes #75


- using gh cli instead of marketplace actions
- specify repo also for the cleanup
