### PR TITLE
fix: fetching correct tag for previous version

### DIFF
--- a/.github/workflows/initiate_version_stub.yml
+++ b/.github/workflows/initiate_version_stub.yml
@@ -28,7 +28,7 @@ jobs:
         # first fetch all the tags
         git fetch --filter=tree:0 origin +refs/tags/*:refs/tags/*
         echo "VERSION=`echo $(echo '${{ github.ref_name }}'|grep -Eo '[0-9]+.[0-9]+.[0-9]+')`" >> $GITHUB_OUTPUT
-        echo "PREVIOUS_VERSION=`echo $(git tag --list | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
+        echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
         echo "AUTHOR=`echo $(git log -1 --pretty=%an)`" >> $GITHUB_OUTPUT
     - name: Get git-chglog and update CHANGELOG
       run: |

--- a/.github/workflows/initiate_version_stub.yml
+++ b/.github/workflows/initiate_version_stub.yml
@@ -28,7 +28,7 @@ jobs:
         # first fetch all the tags
         git fetch --filter=tree:0 origin +refs/tags/*:refs/tags/*
         echo "VERSION=`echo $(echo '${{ github.ref_name }}'|grep -Eo '[0-9]+.[0-9]+.[0-9]+')`" >> $GITHUB_OUTPUT
-        echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
+        echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '^[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
         echo "AUTHOR=`echo $(git log -1 --pretty=%an)`" >> $GITHUB_OUTPUT
     - name: Get git-chglog and update CHANGELOG
       run: |

--- a/.github/workflows/publish_version.yml
+++ b/.github/workflows/publish_version.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git fetch --filter=tree:0 origin +refs/tags/*:refs/tags/*
           echo "VERSION=$(echo ${{ github.head_ref }}|grep -Eo '[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_OUTPUT
-          echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
+          echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '^[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
       - name: Remove previous releases of the target tag, if existing
         if: ${{ steps.published.outputs.labeled == 'false' }}
         run: |

--- a/.github/workflows/publish_version.yml
+++ b/.github/workflows/publish_version.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git fetch --filter=tree:0 origin +refs/tags/*:refs/tags/*
           echo "VERSION=$(echo ${{ github.head_ref }}|grep -Eo '[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_OUTPUT
-          echo "PREVIOUS_VERSION=`echo $(git tag --list | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
+          echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
       - name: Remove previous releases of the target tag, if existing
         if: ${{ steps.published.outputs.labeled == 'false' }}
         run: |

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           git fetch --filter=tree:0 origin +refs/tags/*:refs/tags/*
           echo "VERSION=$(echo ${{ github.ref_name }}|grep -Eo '[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_OUTPUT
-          echo "PREVIOUS_VERSION=`echo $(git tag --list | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
+          echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
       - name: Remove previous releases of the target tag, if existing  # 2
         if: ${{ (steps.published.outputs.labeled == 'false') && steps.get_pr.outputs.pr }}

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           git fetch --filter=tree:0 origin +refs/tags/*:refs/tags/*
           echo "VERSION=$(echo ${{ github.ref_name }}|grep -Eo '[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_OUTPUT
-          echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
+          echo "PREVIOUS_VERSION=`echo $(git tag --list --sort=version:refname | grep -E '^[0-9]+.[0-9]+.[0-9]+$' | tail -n1)`" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
       - name: Remove previous releases of the target tag, if existing  # 2
         if: ${{ (steps.published.outputs.labeled == 'false') && steps.get_pr.outputs.pr }}


### PR DESCRIPTION
Closes #103

Luckily, git provides the option to sort tags according to a versioning logic, with `--sort=version:refname`.

We can also be more restrictive in selecting for clean tags, by enforcing the tag to start directly with the major version number.

---

- sorting tags according to version increase
- stricter condition on the previous version - no v... allowed
